### PR TITLE
Fix compilation error from missing asset manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ generator](https://github.com/CodingZeal/generator-react-zeal) and a
 ## Setup
 
   * Install elixir dependencies with `mix deps.get`
-  * Set up .env config with `mix todo_app.setup`
-  * Create and migrate your database with `mix ecto.setup`
   * Install node dependencies with `npm install`
+  * Create and migrate your database with `mix ecto.setup`
 
 ## Development
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,4 +40,5 @@ config :todo_app, TodoApp.Repo,
   pool_size: 10
 
 config :todo_app, TodoApp.LayoutView,
-  client_path: "//localhost:3000/static/js/bundle.js"
+  client_path: "//localhost:3000/static/js/bundle.js",
+  styles_path: nil

--- a/lib/todo_app/endpoint.ex
+++ b/lib/todo_app/endpoint.ex
@@ -1,6 +1,16 @@
 defmodule TodoApp.Endpoint do
   use Phoenix.Endpoint, otp_app: :todo_app
 
+  if Mix.env == :prod do
+    case File.read("priv/static/asset-manifest.json") do
+      {:ok, content } ->
+        json = Poison.Parser.parse!(content)
+        Application.put_env(:todo_app, TodoApp.LayoutView, json)
+      _ ->
+        :noop
+    end
+  end
+
   if Application.get_env(:todo_app, :sql_sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox
   end

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "postinstall": "npm run build",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "BUILD_PATH=priv/static react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -c client/stories/config",

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -1,21 +1,11 @@
 defmodule TodoApp.LayoutView do
   use TodoApp.Web, :view
 
-  @asset_manifest "priv/static/asset-manifest.json"
-    |> File.read!
-    |> Poison.Parser.parse!
-
   def client_path do
-    case Application.get_env(:todo_app, TodoApp.LayoutView) do
-      [client_path: client_path] -> client_path
-      _ -> @asset_manifest["main.js"]
-    end
+    Application.get_env(:todo_app, TodoApp.LayoutView)[:client_path]
   end
 
   def styles_path do
-    case Application.get_env(:todo_app, TodoApp.LayoutView) do
-      [styles_path: styles_path] -> styles_path
-      _ -> @asset_manifest["main.css"]
-    end
+    Application.get_env(:todo_app, TodoApp.LayoutView)[:styles_path]
   end
 end


### PR DESCRIPTION
- [x] Ensure correct build path is always set when building
- [x] Don't raise if asset manifest is not available in dev

Fixes #1

